### PR TITLE
Add LN explorer (testnet)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Channel Networks](https://www.tik.ee.ethz.ch/file/a20a865ce40d40c8f942cf206a7cba
 - [ln-dice](https://github.com/mably/ln-dice) - Dice gambling service using the Lightning Network for deposits and withdrawals
 - [ln-tip-slack](https://github.com/CryptoFR/ln-tip-slack) - Lightning [Slack](https://slack.com/) Tipbot
 - [lightning-cat](https://github.com/rustyrussell/lightning-cat/blob/master/catsearch.sh) - Cat pictures via Lightning
+- [Lightning network explorer](https://explorer.acinq.co/) - Lightning network explorer (testnet)
 
 ## Developer Resources
 


### PR DESCRIPTION
* Add the Lightning network explorer that is maintained by acinq
> It is useful to have this in the list as it can be used quickly test the working of LN over testnet