### PR TITLE
Add explorers

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributor Covenant Code of Conduct](#contributor-covenant-code-of-conduct)
+  - [Our Pledge](#our-pledge)
+  - [Our Standards](#our-standards)
+  - [Our Responsibilities](#our-responsibilities)
+  - [Scope](#scope)
+  - [Enforcement](#enforcement)
+  - [Attribution](#attribution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/contributing.md
+++ b/contributing.md
@@ -1,3 +1,12 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contribution Guidelines](#contribution-guidelines)
+  - [Updating your PR](#updating-your-pr)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contribution Guidelines
 
 Please note that this project is released with a

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@
 - [Applications](#applications)
   - [Desktop Interfaces](#desktop-interfaces)
   - [Web Interfaces](#web-interfaces)
+  - [Explorers](#explorers)
   - [Misc](#misc)
 - [Developer Resources](#developer-resources)
   - [Libraries](#libraries)
@@ -50,8 +51,7 @@ Implementations of the Lightning Network Protocol
 - [LND API Reference](http://api.lightning.community/)
 - [Lightning Network White Paper](https://lightning.network/lightning-network-paper.pdf)
 - [Deployable Lightning White Paper](https://github.com/ElementsProject/lightning/blob/master/doc/deployable-lightning.pdf)
-- [Scalable Funding of Bitcoin Micropayment
-Channel Networks](https://www.tik.ee.ethz.ch/file/a20a865ce40d40c8f942cf206a7cba96/Scalable_Funding_Of_Blockchain_Micropayment_Networks%20(1).pdf)
+- [Scalable Funding of Bitcoin Micropayment Channel Networks](https://www.tik.ee.ethz.ch/file/a20a865ce40d40c8f942cf206a7cba96/Scalable_Funding_Of_Blockchain_Micropayment_Networks%20(1).pdf)
 
 ## Applications
 
@@ -69,13 +69,19 @@ Channel Networks](https://www.tik.ee.ethz.ch/file/a20a865ce40d40c8f942cf206a7cba
 - [kugelblitz](https://github.com/cdecker/kugelblitz) - A simple UI for the c-lightning daemon lightningd and bitcoind
 - [HTLC Web Lightning Wallet](https://htlc.me) - A web based lightning wallet
 
+### Explorers
+
+- [Lightning network explorer](https://explorer.acinq.co/) - Lightning network explorer (testnet)
+- [Recksplorer](https://lnmainnet.gaben.win/) - Lightning network explorer (mainnet)
+- [Bitcoin Exchange Rate](https://bitcoinexchangerate.org/lightning) - Lightning network explorer (testnet and mainnet)
+- [Robtex Bitcoin Lightning Explorer](https://www.robtex.com/lightning/node/) - Robtex Bitcoin Lightning Explorer (mainnet)
+
 ### Misc
 
 - [lightning-faucet](https://github.com/lightninglabs/lightning-faucet) - A faucet for the Lightning Network
 - [ln-dice](https://github.com/mably/ln-dice) - Dice gambling service using the Lightning Network for deposits and withdrawals
 - [ln-tip-slack](https://github.com/CryptoFR/ln-tip-slack) - Lightning [Slack](https://slack.com/) Tipbot
 - [lightning-cat](https://github.com/rustyrussell/lightning-cat/blob/master/catsearch.sh) - Cat pictures via Lightning
-- [Lightning network explorer](https://explorer.acinq.co/) - Lightning network explorer (testnet)
 - [Bitcoin + Lightning Wallet](https://play.google.com/store/apps/details?id=com.lightning.wallet) - An Android based Lightning Network compatible wallet (based on eclair)
 
 ## Developer Resources


### PR DESCRIPTION
Add a different subsection `Explorers` in light of the multiple explorers that are being maintained for LN. 

The following are the additions:

* Recksplorer - Lightning network explorer (mainnet)
* Bitcoin Exchange Rate - Lightning network explorer (testnet and mainnet)
* Robtex Bitcoin Lightning Explorer - Robtex Bitcoin Lightning Explorer (mainnet)

The following has been shifted from `Misc` subsection to the new `Explorers` subsection:

* Lightning network explorer - Lightning network explorer (testnet)