### PR TITLE
add bos (Balance of satoshis) to the list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Implementations of the Lightning Network Protocol
 - [Ride The Lightning](https://github.com/ShahanaFarooqui/RTL) - Web Client for LND Daemon written in NodeJS /  Angular 7
 - [LND-For-WP](https://github.com/rstmsn/lnd-for-wp) - WordPress plugin for managing & using your LND Node; [WordPress Plugin Directory](https://wordpress.org/plugins/lnd-for-wp/)
 
-### Commandline Interfaces
+### Command Line Interfaces
 
 - [bos – Balance of satoshis](https://github.com/alexbosworth/balanceofsatoshis) - Advanced tool for LND with powerful rebalancing options and telegram bot support written in NodeJS 
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,10 @@ Implementations of the Lightning Network Protocol
 - [Ride The Lightning](https://github.com/ShahanaFarooqui/RTL) - Web Client for LND Daemon written in NodeJS /  Angular 7
 - [LND-For-WP](https://github.com/rstmsn/lnd-for-wp) - WordPress plugin for managing & using your LND Node; [WordPress Plugin Directory](https://wordpress.org/plugins/lnd-for-wp/)
 
+### Commandline Interfaces
+
+- [bos – Balance of satoshis](https://github.com/alexbosworth/balanceofsatoshis) - Advanced tool for LND with powerful rebalancing options and telegram bot support written in NodeJS 
+
 ### Mobile applications
 
 - [rawtx](https://github.com/rawtxapp/rawtxapp) - A lightning network wallet (Android, iOS); [Homepage](https://rawtx.com)


### PR DESCRIPTION
## Description:

Added [bos – Balance of satoshis](https://github.com/alexbosworth/balanceofsatoshis) to the list.
As it is a commandline tool and there was no category yet for it, I also added a new category `Commandline Interfaces`.

[bos – Balance of satoshis](https://github.com/alexbosworth/balanceofsatoshis) is a very powerful tool for rebalancing operations allowing you to specify very precisely which channels to use or to avoid but also has very smart automatic rebalancing logic (see [supported rebalancing options](https://github.com/alexbosworth/balanceofsatoshis/blob/91957107bcd33da5c11c12b037e8a904e88ad8fa/bos#L944-L959))

Additionally it provides telegram bot support which informs you about any activity on your node (forwarding, channel openings/closings). It also can send you a static channel backup file via Telegram each time the channels change (open/close). (It's save to send a static channel backup over unencrypted communication channels, as it's encrypted with the node's seed.)

Very awesome indeed! :)
