### PR TITLE
Remove dead talk link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,9 +203,8 @@ Implementations of the Lightning Network Protocol
 ### Talks
 
 - [Lightning Network Deep Dive with Laolu "Roasbeef" Osuntokun](https://www.youtube.com/watch?v=b_szGaaPPFk) [48:10]
-- [SF Bitcoin Devs Seminar: Scaling Bitcoin to Billions of Transactions Per Day](https://www.youtube.com/watch?v=8zVzw912wPo) [54:40]
+- [SF Bitcoin Devs Seminar: Scaling Bitcoin to Billions of Transactions Per Day](https://www.youtube.com/watch?v=8zVzw912wPo) (Thaddeus Dryja and Joseph Poon)[54:40]
 - [Bitcoin, Lightning, and Streaming Money](https://www.youtube.com/watch?v=gF_ZQ_eijPs) (Andreas Antonopoulos) [27:38]
-- [Lightning Network Tech Talk at Coinbase](https://www.youtube.com/watch?v=wIhAmTqXhZQ) (Thaddeus Dryja and Joseph Poon) [58:11]
 - [Lightning and the Importance of Layer Two](https://www.youtube.com/watch?v=3PcR4HWJnkY) (Elizabeth Stark) [14:15]
 - [Bitcoin Q&A: The Lightning Network](https://www.youtube.com/watch?v=vPnO9ExJ50A)  (Andreas Antonopoulos) [7:55]
 


### PR DESCRIPTION
There is already another talk with Dryja and Poon, so moving the names up. I don't know why the original link is dead, and I can't find it archived.