### PR TITLE
add sataddress-rs next to current lightning address project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Implementations of the Lightning Network Protocol
 ### Misc
 
 - [lightning-address-nodejs](https://github.com/mefatbear/lightning-address-nodejs) - Simple server for your personal Lightning Address
+- [sataddress-rs](https://github.com/bernii/sataddress-rs) - Lightning Address Federated Server implementation (in Rust)
 - [bitcoin-kit-makefile](https://github.com/Perlover/bitcoin-kit-makefile) - Easy installation of full bitcoin and lightning nodes from sources
 - [ifpaytt](https://github.com/ElementsProject/ifpaytt) - IFTTT (If Pay Then This) based on Lightning payments; [Blog Post](https://blockstream.com/2018/03/27/ifpaytt-brings-lightning-micropayments-to-ifttt.html)
 - [lightning-faucet](https://github.com/lightninglabs/lightning-faucet) - A faucet for the Lightning Network


### PR DESCRIPTION
adding the sataddress-rs project in the `Misc` section which allows running self-served Lightning Address federated server to handle domain aliases 