### PR TITLE
docs: audit links and remove defunct resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,17 +62,17 @@ Implementations of the Lightning Network Protocol
 
 ### Desktop Interfaces
 
-- [lightning-app](https://github.com/lightninglabs/lightning-app) - Cross-platform Lightning Desktop Application
-- [lnd-gui](https://github.com/alexbosworth/lnd-gui) - Lightning MacOS GUI Wallet
+- [lightning-app](https://github.com/lightninglabs/lightning-app) - Cross-platform Lightning Desktop Application  [Archived]
+- [lnd-gui](https://github.com/alexbosworth/lnd-gui) - Lightning MacOS GUI Wallet  [Archived]
 - [eclair-node-gui](https://github.com/ACINQ/eclair) - Cross-platform desktop GUI for Lightning
-- [zap-desktop](https://github.com/LN-Zap/zap-desktop) - Lightning Network desktop application
-- [Presto](https://github.com/icota/presto) - c-lightning based desktop wallet
+- [zap-desktop](https://github.com/LN-Zap/zap-desktop) - Lightning Network desktop application  
+- [Presto](https://github.com/icota/presto) - c-lightning based desktop wallet   [Archived]
 - [Lightning Peach Wallet](https://github.com/LightningPeach/lightning-peach-wallet) - Bitfury Lightning Wallet
 - [spark-wallet](https://github.com/shesek/spark-wallet) - Minimal GUI for c-lightning; available as web, mobile and desktop application
 - [Voltage](https://github.com/benharold/voltage) - Voltage is a macOS GUI for c-lightning
 - [Node-launcher](https://github.com/lightning-power-users/node-launcher) - Quickly install BTC and launch the LN desktop app
-- [Sparkswap Desktop](https://github.com/sparkswap/sparkswap-desktop) - Buy BTC using USD and LND
-- [ShockWizard](https://github.com/shocknet/Wizard) - Install a Shockwallet LND node on any Desktop/Laptop in just a few clicks.
+- [Sparkswap Desktop](https://github.com/sparkswap/sparkswap-desktop) - Buy BTC using USD and LND  [Archived]
+- [ShockWizard](https://github.com/shocknet/Wizard) - Install a Shockwallet LND node on any Desktop/Laptop in just a few clicks.  [Archived]
 
 ### Web Interfaces
 
@@ -95,10 +95,8 @@ Implementations of the Lightning Network Protocol
 
 ### Mobile applications
 
-- [rawtx](https://github.com/rawtxapp/rawtxapp) - A lightning network wallet (Android, iOS); [Homepage](https://rawtx.com)
+- [rawtx](https://github.com/rawtxapp/rawtxapp) - A lightning network wallet (Android, iOS); [Homepage](https://rawtx.com)  [Archived]
 - [Swift Lightning](https://github.com/biscottigelato/SwiftLightning) - LN wallet build on top of LND for iOS
-- [Bitcoin Lightning Wallet](https://play.google.com/store/apps/details?id=com.lightning.walletapp)  - An Android based Lightning Network compatible wallet based on Eclair ([testnet version](https://play.google.com/store/apps/details?id=com.lightning.wallet))
-- [Eclair Mobile](https://play.google.com/store/apps/details?id=fr.acinq.eclair.wallet.mainnet2)
 - [Globular](https://gitlab.com/inbitcoin/globular) - cross-implementation LN Android remote wallet, connects to a Lighter instance (see [Libraries](#libraries) section)
 - [Muun](https://muun.com/) - A Lightning Network wallet for Android. ([Github](https://github.com/muun/apollo))
 - [Shockwallet](https://shockwallet.app) - A Lightning SuperApp and Decentralized Social Network. ([Github](https://github.com/shocknet/wallet))
@@ -109,11 +107,7 @@ Implementations of the Lightning Network Protocol
 
 - [1ML](https://1ml.com/) - 1ML explorer (mainnet + testnet)
 - [Amboss.space](https://amboss.space/) - Amboss.space explorer
-- [Bitcoin Exchange Rate](https://bitcoinexchangerate.org/lightning) - Lightning network explorer (testnet and mainnet)
-- [Lightblock](https://lightblock.me) - lightning network explorer mainnet.
-- [Lightning network explorer](https://explorer.acinq.co/) - Lightning network explorer (testnet)
 - [List of explorers](https://gist.github.com/bretton/798ec38165ffabc719d91e0f4f67552d) - meta list of visualisers and metrics sites
-- [lngraph](https://github.com/xsb/lngraph) - Personal private Lightning Network explorer using Neo4j Browser.
 - [Robtex Bitcoin Lightning Explorer](https://www.robtex.com/lightning/node/) - Robtex Bitcoin Lightning Explorer (mainnet)
 
 ### Misc


### PR DESCRIPTION
This PR addresses multiple broken and outdated links identified during a technical audit:

Removed: 6 links that were 404, unsecured, or "not found" (e.g., Bitcoin Exchange Rate, Lightblock).

Updated: Marked 6 repositories as [Archived] to provide better context for users (e.g., lightning-app, rawtx).

These changes ensure that the "Awesome Lightning Network" list remains a high-quality, reliable entry point for new developers.